### PR TITLE
amends logic on queries, ignores queries not yet built but protects against invalid query options

### DIFF
--- a/__tests__/intergration.test.js
+++ b/__tests__/intergration.test.js
@@ -84,7 +84,7 @@ describe("GET: /api/articles", () => {
         });
       });
   });
-  test("200: returns articles with selected topic ignoring anything else invalid on query", () => {
+  test("200: returns articles with selected topic ignoring anything else on query", () => {
     return request(app)
       .get("/api/articles?category=computer&topic=mitch")
       .expect(200)
@@ -113,7 +113,7 @@ describe("GET: /api/articles", () => {
         });
       });
   });
-  test("200: resolves with list of articles sorted by valid column DESC ignoring invalid queries", () => {
+  test("200: resolves with list of articles sorted by valid column DESC ignoring other queries", () => {
     return request(app)
       .get("/api/articles?sort_by=author&computer=windows")
       .expect(200)
@@ -149,7 +149,7 @@ describe("GET: /api/articles", () => {
         });
       });
   });
-  test("200: resolves with list of articles ordered by valid option ignoring invalid queries", () => {
+  test("200: resolves with list of articles ordered by valid option ignoring other queries", () => {
     return request(app)
       .get("/api/articles?order=asc&computer=mac")
       .expect(200)
@@ -164,7 +164,7 @@ describe("GET: /api/articles", () => {
       .get("/api/articles?order=doesnt_exist")
       .expect(400)
       .then(({ body: { msg } }) => {
-        expect(msg).toBe("Bad request");
+        expect(msg).toBe("Bad request - invalid query");
       });
   });
   test("400: sends appropriate message and status when passed multiple order queries", () => {
@@ -172,7 +172,7 @@ describe("GET: /api/articles", () => {
       .get("/api/articles?order=asc&order=desc")
       .expect(400)
       .then(({ body: { msg } }) => {
-        expect(msg).toBe("Bad request");
+        expect(msg).toBe("Bad request - invalid query");
       });
   });
   test("200: resolves with list of articles sorted by valid column and ordered by valid option", () => {
@@ -196,14 +196,6 @@ describe("GET: /api/articles", () => {
         articles.forEach((article) => {
           expect(article.topic).toBe("mitch");
         });
-      });
-  });
-  test("400: sends appropriate msg and status when passed invalid query", () => {
-    return request(app)
-      .get("/api/articles?category=computer")
-      .expect(400)
-      .then(({ body: { msg } }) => {
-        expect(msg).toBe("Bad request - invalid query");
       });
   });
 });

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -5,7 +5,8 @@ const {
 } = require("../models/articles.models");
 
 exports.getArticles = (req, res, next) => {
-  findArticles(req.query)
+  const { sort_by, order, topic } = req.query;
+  findArticles(sort_by, order, topic)
     .then((articles) => {
       res.status(200).send({ articles });
     })

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -1,15 +1,11 @@
 const db = require("../db/connection");
 
-exports.findArticles = (queryObj) => {
-  const validQueries = ["topic", "sort_by", "order"];
-  const checkQueryKeys = Object.keys(queryObj).filter((item) =>
-    validQueries.includes(item)
-  );
-  if (Object.keys(queryObj).length && !checkQueryKeys.length) {
+exports.findArticles = (sort_by, order, topic) => {
+  const validQueries = ["asc", "desc"];
+
+  if (order && !validQueries.includes(order)) {
     return Promise.reject({ status: 400, msg: "Bad request - invalid query" });
   }
-
-  const { topic, sort_by, order } = queryObj;
 
   const queryValues = [];
   let queryString = `SELECT articles.author, title, article_id, topic, articles.created_at, 


### PR DESCRIPTION
Hello, 

This adjusts my queries logic for Topic, Order and Sort_By.
The code no longer rejects query keys that haven't been built yet but will ignore them.
Instead, it now checks the order options to protect against SQL injections and leaves PSQL to handle errors on unknown column names.

Due to all three being in the same file this branch also amends code from task 15. 

PS. Is this sufficient to protect against SQL injection for sort_by? or would we need to filter out those column names first?

Many thanks, 
Maddie 